### PR TITLE
docs(backend): add DATA_MODEL and schema_version with tests

### DIFF
--- a/backend/schema_version.py
+++ b/backend/schema_version.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+CURRENT_VERSION = "0.1.0"
+
+
+def get_version() -> str:
+    return CURRENT_VERSION
+
+
+def is_compatible(ver: str) -> bool:
+    """
+    Compatibility policy: match by major version.
+    Versions with the same major number are considered compatible.
+    """
+    try:
+        major_current = CURRENT_VERSION.split(".")[0]
+        major_input = ver.split(".")[0]
+        return major_current == major_input
+    except Exception:
+        return False
+

--- a/backend/schema_version.py
+++ b/backend/schema_version.py
@@ -18,4 +18,3 @@ def is_compatible(ver: str) -> bool:
         return major_current == major_input
     except Exception:
         return False
-

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,20 @@
+# Data Model
+
+This document describes the backend data transfer objects (DTOs), their serialized form, and basic compatibility guarantees.
+
+## DTOs
+
+- PointDTO: `{ "x": float, "y": float }`
+- SegmentDTO: `{ "a": PointDTO, "b": PointDTO }`
+- CircleDTO: `{ "center": PointDTO, "r": float }`
+- FilletArcDTO: `{ "center": PointDTO, "r": float, "t1": PointDTO, "t2": PointDTO }`
+
+## Schema Version
+
+- Current: `0.1.0` (see `backend/schema_version.py`).
+- Compatibility policy: same major version is considered compatible for loading.
+
+## Serialization
+
+Pure JSON objects with primitive number fields. Serializers live in `backend/serializers.py` and provide `to_dict_*` and `from_dict_*` helpers for each DTO.
+

--- a/tasks/docs-data-model-and-schema-version.md
+++ b/tasks/docs-data-model-and-schema-version.md
@@ -1,0 +1,18 @@
+Task: Docs + Backend – Data model and schema version
+
+Scope
+- Author `docs/DATA_MODEL.md` describing DTOs, entities, and relationships.
+- Add `backend/schema_version.py` with `CURRENT_VERSION = "0.1.0"` and helpers.
+
+Details
+- Document serialization format and compatibility policy.
+- Provide `get_version()` and `is_compatible(ver: str) -> bool` for loaders.
+- Include unit tests in `tests/backend/test_schema_version.py`.
+
+Acceptance
+- Docs build/read cleanly; tests pass.
+- `ruff` and `black --check` pass.
+
+Branch
+- `docs/data-model-and-schema-version`
+

--- a/tasks/pr/docs-data-model-and-schema-version.md
+++ b/tasks/pr/docs-data-model-and-schema-version.md
@@ -1,0 +1,30 @@
+Title: docs(backend): add DATA_MODEL and schema_version with tests
+
+Summary
+- Documents backend DTOs and their JSON serialization format.
+- Adds `backend/schema_version.py` with `CURRENT_VERSION` and compatibility helpers, plus tests.
+
+Changes
+- New: `docs/DATA_MODEL.md`
+- New: `backend/schema_version.py`
+- New: `tests/backend/test_schema_version.py`
+- Task: `tasks/docs-data-model-and-schema-version.md`
+
+Rationale
+- Clarify data interchange and provide forward-compat policy for loaders/saves.
+- Make version access/compatibility easy and test-covered.
+
+Test Plan (agents pulling this)
+- From repo root:
+  - `python -m pip install -e .` (or set `PYTHONPATH` to repo root)
+  - `ruff check backend/schema_version.py tests/backend/test_schema_version.py`
+  - `black --check backend/schema_version.py tests/backend/test_schema_version.py`
+  - `pytest -q tests/backend/test_schema_version.py`
+
+Notes
+- Compatibility policy: load accepts same major version; otherwise false.
+- Keep docs and constant in sync when bumping.
+
+Refs
+- Issue: N/A (please update if applicable)
+

--- a/tests/backend/test_schema_version.py
+++ b/tests/backend/test_schema_version.py
@@ -1,0 +1,20 @@
+from backend.schema_version import CURRENT_VERSION, get_version, is_compatible
+
+
+def test_get_version_matches_constant():
+    assert get_version() == CURRENT_VERSION
+
+
+def test_is_compatible_same_version_true():
+    assert is_compatible(CURRENT_VERSION)
+
+
+def test_is_compatible_major_mismatch_false():
+    assert not is_compatible("1.0.0")
+
+
+def test_is_compatible_minor_bump_true():
+    # Same major version considered compatible
+    major = CURRENT_VERSION.split(".")[0]
+    assert is_compatible(f"{major}.99.0")
+

--- a/tests/backend/test_schema_version.py
+++ b/tests/backend/test_schema_version.py
@@ -17,4 +17,3 @@ def test_is_compatible_minor_bump_true():
     # Same major version considered compatible
     major = CURRENT_VERSION.split(".")[0]
     assert is_compatible(f"{major}.99.0")
-


### PR DESCRIPTION
Title: docs(backend): add DATA_MODEL and schema_version with tests

Summary
- Documents backend DTOs and their JSON serialization format.
- Adds `backend/schema_version.py` with `CURRENT_VERSION` and compatibility helpers, plus tests.

Changes
- New: `docs/DATA_MODEL.md`
- New: `backend/schema_version.py`
- New: `tests/backend/test_schema_version.py`
- Task: `tasks/docs-data-model-and-schema-version.md`

Rationale
- Clarify data interchange and provide forward-compat policy for loaders/saves.
- Make version access/compatibility easy and test-covered.

Test Plan (agents pulling this)
- From repo root:
  - `python -m pip install -e .` (or set `PYTHONPATH` to repo root)
  - `ruff check backend/schema_version.py tests/backend/test_schema_version.py`
  - `black --check backend/schema_version.py tests/backend/test_schema_version.py`
  - `pytest -q tests/backend/test_schema_version.py`

Notes
- Compatibility policy: load accepts same major version; otherwise false.
- Keep docs and constant in sync when bumping.

Refs
- Issue: N/A (please update if applicable)

