### PR TITLE
test(backend): add OpsService.create_segment test

### DIFF
--- a/tasks/pr/chore-backend-ops-service-tests.md
+++ b/tasks/pr/chore-backend-ops-service-tests.md
@@ -1,0 +1,23 @@
+Title: test(backend): add CRUD-like test for OpsService create_segment
+
+Summary
+- Adds a targeted test for `OpsService.create_segment` to ensure the created segment is persisted via `InMemoryGeomRepo` and returns a proper `EntityRef`.
+
+Changes
+- New: `tests/backend/test_ops_service.py`
+
+Rationale
+- Provide a basic contract check for the ops service wiring before adding more operations (trim/extend).
+
+Test Plan (agents pulling this)
+- From repo root:
+  - `python -m pip install -e .` (or set `PYTHONPATH` to repo root)
+  - `ruff check tests/backend/test_ops_service.py`
+  - `black --check tests/backend/test_ops_service.py`
+  - `pytest -q tests/backend/test_ops_service.py`
+
+Notes
+- No external side effects; uses in-memory repo.
+
+Refs
+- Issue: N/A (update if applicable)

--- a/tests/backend/test_ops_service.py
+++ b/tests/backend/test_ops_service.py
@@ -1,0 +1,17 @@
+from backend.geom_repo import InMemoryGeomRepo
+from backend.models import PointDTO
+from backend.ops_service import OpsService
+
+
+def test_create_segment_adds_entity_to_repo():
+    repo = InMemoryGeomRepo()
+    svc = OpsService(repo=repo)
+
+    ref = svc.create_segment(PointDTO(0.0, 0.0), PointDTO(1.0, 1.0))
+    assert ref.kind == "segment"
+    assert ref.id.startswith("segment:")
+
+    seg = repo.get_segment(ref.id)
+    assert seg is not None
+    assert seg.a == PointDTO(0.0, 0.0)
+    assert seg.b == PointDTO(1.0, 1.0)


### PR DESCRIPTION
Title: test(backend): add CRUD-like test for OpsService create_segment

Summary
- Adds a targeted test for `OpsService.create_segment` to ensure the created segment is persisted via `InMemoryGeomRepo` and returns a proper `EntityRef`.

Changes
- New: `tests/backend/test_ops_service.py`

Rationale
- Provide a basic contract check for the ops service wiring before adding more operations (trim/extend).

Test Plan (agents pulling this)
- From repo root:
  - `python -m pip install -e .` (or set `PYTHONPATH` to repo root)
  - `ruff check tests/backend/test_ops_service.py`
  - `black --check tests/backend/test_ops_service.py`
  - `pytest -q tests/backend/test_ops_service.py`

Notes
- No external side effects; uses in-memory repo.

Refs
- Issue: N/A (update if applicable)