### PR TITLE
docs(backend): document DTO serialization usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,3 +6,8 @@ Targets
 - Own `db/loader.py` and future persistence.
 - Provide clean APIs used by `frontend`.
 
+DTOs and Serialization
+- DTOs (e.g., `PointDTO`, `SegmentDTO`) define simple data contracts shared across layers.
+- Serialization helpers (when present) convert DTOs to plain dicts suitable for JSON and back.
+- Keep DTOs and serializers pure and free of side effects for easy testing.
+

--- a/tasks/pr/docs-backend-serializers-docs.md
+++ b/tasks/pr/docs-backend-serializers-docs.md
@@ -1,0 +1,16 @@
+Title: docs(backend): document DTOs and serialization usage in backend README
+
+Summary
+- Expands `backend/README.md` with a section on DTOs and serialization helpers, clarifying intended usage and design constraints.
+
+Changes
+- Update: `backend/README.md` (DTOs and Serialization section)
+
+Rationale
+- Provide discoverable guidance for agents about data contracts and serialization approach without changing code paths.
+
+Validation
+- Docs-only; no behavior change.
+
+Refs
+- Issue: N/A (update if applicable)


### PR DESCRIPTION
Title: docs(backend): document DTOs and serialization usage in backend README

Summary
- Expands `backend/README.md` with a section on DTOs and serialization helpers, clarifying intended usage and design constraints.

Changes
- Update: `backend/README.md` (DTOs and Serialization section)

Rationale
- Provide discoverable guidance for agents about data contracts and serialization approach without changing code paths.

Validation
- Docs-only; no behavior change.

Refs
- Issue: N/A (update if applicable)