### PR TITLE
chore(ci): align PR labeler with repo labels + agent:auto

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,17 +14,20 @@ jobs:
             const branch = context.payload.pull_request.head.ref;
             const labels = new Set();
 
-            // Type by prefix
-            if (branch.startsWith('feat/')) labels.add('type: feature');
-            if (branch.startsWith('fix/')) labels.add('type: fix');
-            if (branch.startsWith('chore/')) labels.add('type: chore');
+            // Type by prefix (align with repo labels)
+            if (branch.startsWith('feat/')) labels.add('type:feature');
+            if (branch.startsWith('fix/')) labels.add('type:fix');
+            if (branch.startsWith('chore/')) labels.add('type:chore');
 
-            // Area by path fragment
-            if (branch.includes('cad-core')) labels.add('area: cad-core');
-            if (branch.includes('backend')) labels.add('area: backend');
-            if (branch.includes('frontend')) labels.add('area: frontend');
-            if (branch.includes('qa')) labels.add('area: qa');
-            if (branch.includes('integration')) labels.add('area: integration');
+            // Area by branch fragment (align with repo labels)
+            if (branch.includes('cad-core') || branch.includes('cad_core')) labels.add('area:cad_core');
+            if (branch.includes('backend')) labels.add('area:backend');
+            if (branch.includes('frontend')) labels.add('area:frontend');
+            if (branch.includes('qa')) labels.add('area:qa');
+            if (branch.includes('integration')) labels.add('area:integration');
+
+            // Mark PRs created by automation to help triage
+            labels.add('agent:auto');
 
             // Ensure labels exist
             for (const name of labels) {


### PR DESCRIPTION
- Use existing label names: type:*, area:* (no spaces)\n- Detect cad_core as well as cad-core in branch names\n- Always add agent:auto to PRs for easier triage