### PR TITLE
test(cad_core): xfail scaffolds for trim/extend arc-line ops

### DIFF
--- a/tasks/pr/chore-cad-core-trim-suite-xfail.md
+++ b/tasks/pr/chore-cad-core-trim-suite-xfail.md
@@ -1,0 +1,22 @@
+Title: test(cad_core): add xfail scaffolds for trim/extend arc-line operations
+
+Summary
+- Adds placeholder xfail tests to guide implementation of arc-line trim/extend operations without breaking CI.
+
+Changes
+- New: `tests/cad_core/test_trim_suite_xfail.py` (3 xfail tests with rationale)
+
+Rationale
+- Provide concrete acceptance targets for upcoming geometry work.
+- Keep main green via xfail markers until implemented.
+
+Test Plan (agents pulling this)
+- `ruff check tests/cad_core/test_trim_suite_xfail.py`
+- `black --check tests/cad_core/test_trim_suite_xfail.py`
+- `pytest -q tests/cad_core/test_trim_suite_xfail.py` (shows 3 xfailed)
+
+Notes
+- No runtime imports of unimplemented APIs; tests call `pytest.xfail` directly with reasons.
+
+Refs
+- Task: `tasks/feat-cad-core-trim-suite.md`

--- a/tests/cad_core/test_trim_suite_xfail.py
+++ b/tests/cad_core/test_trim_suite_xfail.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.mark.xfail(reason="arc trim/extend not implemented yet")
+def test_trim_arc_by_line_xfail():
+    # Placeholder for future API: trim an Arc to a Line cutter
+    # Expected: returns a new Arc with end snapped to intersection tangent point
+    pytest.xfail("not implemented")
+
+
+@pytest.mark.xfail(reason="segment-circle extend not implemented yet")
+def test_extend_segment_to_circle_xfail():
+    # Placeholder: extend a segment endpoint to intersect a circle
+    # Expected: new segment endpoint lies on the circle at nearest intersection
+    pytest.xfail("not implemented")
+
+
+@pytest.mark.xfail(reason="line-arc trim not implemented yet")
+def test_trim_line_by_arc_xfail():
+    # Placeholder: trim a line by an arc cutter (finite arc)
+    # Expected: moves chosen endpoint to intersection with the arc if exists
+    pytest.xfail("not implemented")


### PR DESCRIPTION
Title: test(cad_core): add xfail scaffolds for trim/extend arc-line operations

Summary
- Adds placeholder xfail tests to guide implementation of arc-line trim/extend operations without breaking CI.

Changes
- New: `tests/cad_core/test_trim_suite_xfail.py` (3 xfail tests with rationale)

Rationale
- Provide concrete acceptance targets for upcoming geometry work.
- Keep main green via xfail markers until implemented.

Test Plan (agents pulling this)
- `ruff check tests/cad_core/test_trim_suite_xfail.py`
- `black --check tests/cad_core/test_trim_suite_xfail.py`
- `pytest -q tests/cad_core/test_trim_suite_xfail.py` (shows 3 xfailed)

Notes
- No runtime imports of unimplemented APIs; tests call `pytest.xfail` directly with reasons.

Refs
- Task: `tasks/feat-cad-core-trim-suite.md`