### PR TITLE
feat(cad_core): trim_line_by_arc + extend_segment_to_circle

### DIFF
--- a/cad_core/lines.py
+++ b/cad_core/lines.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -9,7 +8,7 @@ class Point:
     x: float
     y: float
 
-    def as_tuple(self) -> Tuple[float, float]:
+    def as_tuple(self) -> tuple[float, float]:
         return (float(self.x), float(self.y))
 
 
@@ -18,7 +17,7 @@ class Line:
     a: Point
     b: Point
 
-    def as_tuple(self) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+    def as_tuple(self) -> tuple[tuple[float, float], tuple[float, float]]:
         return (self.a.as_tuple(), self.b.as_tuple())
 
 
@@ -42,7 +41,7 @@ def _dot(p: Point, q: Point) -> float:
     return p.x * q.x + p.y * q.y
 
 
-def intersection_line_line(l1: Line, l2: Line, tol: float = 1e-9) -> Optional[Point]:
+def intersection_line_line(l1: Line, l2: Line, tol: float = 1e-9) -> Point | None:
     """Return intersection point of two infinite lines, or None if parallel.
 
     Uses a 2D cross-product formulation. Treats lines as infinite; trimming is separate.
@@ -62,6 +61,13 @@ def intersection_line_line(l1: Line, l2: Line, tol: float = 1e-9) -> Optional[Po
     t = _cross(q_p, s) / rxs
     # u = _cross(q_p, r) / rxs  # not needed for the point itself
     return _add(p, _scale(r, t))
+
+
+def is_parallel(l1: Line, l2: Line, tol: float = 1e-9) -> bool:
+    """Return True if the direction vectors of the lines are parallel within tol."""
+    r = _sub(l1.b, l1.a)
+    s = _sub(l2.b, l2.a)
+    return abs(_cross(r, s)) <= tol
 
 
 def nearest_point_on_line(line: Line, p: Point) -> Point:
@@ -89,7 +95,7 @@ def is_point_on_segment(p: Point, seg: Line, tol: float = 1e-9) -> bool:
     return _dot(ap, ab) >= -tol and _dot(bp, _sub(a, b)) >= -tol
 
 
-def intersection_segment_segment(s1: Line, s2: Line, tol: float = 1e-9) -> Optional[Point]:
+def intersection_segment_segment(s1: Line, s2: Line, tol: float = 1e-9) -> Point | None:
     """Intersection point of two finite segments, or None."""
     ip = intersection_line_line(s1, s2, tol=tol)
     if ip is None:
@@ -112,7 +118,9 @@ def extend_line_end_to_point(line: Line, target: Point, end: str = "b") -> Line:
     return Line(a=line.a, b=target)
 
 
-def extend_line_to_intersection(line: Line, other: Line, end: str = "b", tol: float = 1e-9) -> Optional[Line]:
+def extend_line_to_intersection(
+    line: Line, other: Line, end: str = "b", tol: float = 1e-9
+) -> Line | None:
     """Extend one end of 'line' to meet the infinite intersection with 'other'.
 
     Returns a new Line or None if lines are parallel (no intersection).
@@ -124,7 +132,7 @@ def extend_line_to_intersection(line: Line, other: Line, end: str = "b", tol: fl
     return extend_line_end_to_point(line, ip, end=end)
 
 
-def trim_line_by_cut(line: Line, cutter: Line, end: str = "b", tol: float = 1e-9) -> Optional[Line]:
+def trim_line_by_cut(line: Line, cutter: Line, end: str = "b", tol: float = 1e-9) -> Line | None:
     """Trim a line segment towards its intersection with a cutter.
 
     If the infinite lines intersect, this moves the chosen endpoint of `line`
@@ -138,7 +146,9 @@ def trim_line_by_cut(line: Line, cutter: Line, end: str = "b", tol: float = 1e-9
     return extend_line_end_to_point(line, ip, end=end)
 
 
-def trim_segment_by_cutter(seg: Line, cutter: Line, end: str = "b", tol: float = 1e-9) -> Optional[Line]:
+def trim_segment_by_cutter(
+    seg: Line, cutter: Line, end: str = "b", tol: float = 1e-9
+) -> Line | None:
     """Trim a finite segment to the intersection with a cutter segment.
 
     Returns new segment or None if no valid intersection lies on both segments.
@@ -147,6 +157,72 @@ def trim_segment_by_cutter(seg: Line, cutter: Line, end: str = "b", tol: float =
     if ip is None:
         return None
     return extend_line_end_to_point(seg, ip, end=end)
+
+
+def extend_segment_to_circle(
+    seg: Line, circle: Circle, end: str = "b", tol: float = 1e-9
+) -> Line | None:
+    """Extend one end of a segment to the nearest intersection with a circle.
+
+    Returns a new segment or None if the supporting line does not intersect the circle.
+    """
+    # Local import to avoid circular dependency at module import time
+    from .circle import line_circle_intersections
+
+    ips = line_circle_intersections(seg, circle, tol=tol)
+    if not ips:
+        return None
+    endpoint = seg.b if end == "b" else seg.a
+    other = seg.a if end == "b" else seg.b
+    # For extend, move from endpoint outward along segment direction
+    v = _sub(endpoint, other)
+    denom = _dot(v, v)
+    if denom <= tol:
+        return None
+    cand = []
+    for p in ips:
+        t = _dot(_sub(p, endpoint), v) / denom
+        if t >= -tol:
+            cand.append(p)
+    if not cand:
+        return None
+    target = min(cand, key=lambda p: (p.x - endpoint.x) ** 2 + (p.y - endpoint.y) ** 2)
+    return extend_line_end_to_point(seg, target, end=end)
+
+
+def trim_line_by_arc(line: Line, arc: Arc, end: str = "b", tol: float = 1e-9) -> Line | None:
+    """Trim a line to the nearest intersection with a finite arc.
+
+    Intersects the supporting line with the arc's circle and picks the closest
+    intersection that lies on the arc sweep. Returns None if there is none.
+    """
+    # Local imports to avoid circular dependency
+    from .arc import is_point_on_arc
+    from .circle import Circle, line_circle_intersections
+
+    circle = Circle(arc.center, arc.radius)
+    ips = [
+        p
+        for p in line_circle_intersections(line, circle, tol=tol)
+        if is_point_on_arc(arc, p, tol=tol)
+    ]
+    if not ips:
+        return None
+    endpoint = line.b if end == "b" else line.a
+    other = line.a if end == "b" else line.b
+    w = _sub(other, endpoint)
+    denom = _dot(w, w)
+    if denom <= tol:
+        return None
+    cand = []
+    for p in ips:
+        t = _dot(_sub(p, endpoint), w) / denom
+        if -tol <= t <= 1 + tol:
+            cand.append(p)
+    if not cand:
+        return None
+    target = min(cand, key=lambda p: (p.x - endpoint.x) ** 2 + (p.y - endpoint.y) ** 2)
+    return extend_line_end_to_point(line, target, end=end)
 
 
 __all__ = [
@@ -163,3 +239,7 @@ __all__ = [
     "trim_segment_by_cutter",
 ]
 
+__all__ += [
+    "extend_segment_to_circle",
+    "trim_line_by_arc",
+]

--- a/tests/cad_core/test_extend_and_trim_arc_line.py
+++ b/tests/cad_core/test_extend_and_trim_arc_line.py
@@ -1,0 +1,28 @@
+from cad_core.arc import Arc
+from cad_core.circle import Circle
+from cad_core.lines import Line, Point, extend_segment_to_circle, trim_line_by_arc
+
+
+def test_extend_segment_to_circle_picks_nearest_intersection():
+    seg = Line(Point(0, 0), Point(1, 0))
+    circ = Circle(Point(0, 0), 5.0)
+    out = extend_segment_to_circle(seg, circ, end="b")
+    assert out is not None
+    assert out.a == seg.a
+    assert abs(out.b.x - 5.0) < 1e-9 and abs(out.b.y - 0.0) < 1e-9
+
+
+def test_trim_line_by_arc_uses_arc_sweep():
+    # Arc: radius 5 from angle 0 to pi/2 CCW (quadrant I)
+    center = Point(0, 0)
+    arc = Arc(center=center, radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    # Line along x-axis
+    base = Line(Point(0, 0), Point(10, 0))
+    out = trim_line_by_arc(base, arc, end="b")
+    assert out is not None
+    assert abs(out.b.x - 5.0) < 1e-9 and abs(out.b.y - 0.0) < 1e-9
+
+    # Negative-x segment: trimming 'a' should not jump across to +x arc point
+    base2 = Line(Point(-10, 0), Point(0, 0))
+    out2 = trim_line_by_arc(base2, arc, end="a")
+    assert out2 is None


### PR DESCRIPTION
Title: feat(cad_core): add trim/extend helpers for arc-line and segment-circle

Summary
- Adds `extend_segment_to_circle` (segment ? nearest circle intersection in forward direction) and
  `trim_line_by_arc` (line ? nearest intersection constrained to arc sweep and towards shortening).
- Includes tests: `tests/cad_core/test_extend_and_trim_arc_line.py`.

Changes
- Update: `cad_core/arc.py` with `is_point_on_arc` utility.
- Update: `cad_core/lines.py` with new helpers and `is_parallel` (used by existing tests).
- New: `tests/cad_core/test_extend_and_trim_arc_line.py`.

Rationale
- Advance the trim/extend suite for practical CAD operations while preserving pure, testable functions.

Test Plan
- `ruff check cad_core tests/cad_core/test_extend_and_trim_arc_line.py`
- `black --check cad_core tests/cad_core/test_extend_and_trim_arc_line.py`
- `pytest -q tests/cad_core/test_extend_and_trim_arc_line.py` (2 passed)

Notes
- Circular imports avoided via local imports and string-type annotations.
- Directional selection prevents extending when trimming and vice versa.

Refs
- Task: `tasks/feat-cad-core-trim-suite.md`