### PR TITLE
feat(cad_core): trim_segment_by_arc + tests

### DIFF
--- a/cad_core/arc.py
+++ b/cad_core/arc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Tuple
 
 from .lines import Point, _sub
 
@@ -12,7 +11,7 @@ class Arc:
     center: Point
     radius: float
     start_angle: float  # radians
-    end_angle: float    # radians
+    end_angle: float  # radians
     ccw: bool = True
 
 
@@ -42,3 +41,33 @@ def arc_from_points(center: Point, p_start: Point, p_end: Point, prefer_short: b
 
 __all__ = ["Arc", "arc_from_points"]
 
+
+def _norm_angle(a: float) -> float:
+    a = a % (2 * math.pi)
+    if a < 0:
+        a += 2 * math.pi
+    return a
+
+
+def is_point_on_arc(arc: Arc, p: Point, tol: float = 1e-9) -> bool:
+    """Return True if point p lies on the finite arc within tolerance.
+
+    Checks both radial distance and angular position within the arc sweep.
+    """
+    r = math.hypot(p.x - arc.center.x, p.y - arc.center.y)
+    if abs(r - arc.radius) > tol:
+        return False
+    ap = _norm_angle(_angle(arc.center, p))
+    a0 = _norm_angle(arc.start_angle)
+    a1 = _norm_angle(arc.end_angle)
+    if arc.ccw:
+        if a0 <= a1:
+            return a0 - tol <= ap <= a1 + tol
+        return ap >= a0 - tol or ap <= a1 + tol
+    else:
+        if a1 <= a0:
+            return a1 - tol <= ap <= a0 + tol
+        return ap <= a0 + tol or ap >= a1 - tol
+
+
+__all__ += ["is_point_on_arc"]

--- a/tests/cad_core/test_trim_segment_by_arc.py
+++ b/tests/cad_core/test_trim_segment_by_arc.py
@@ -1,0 +1,28 @@
+from cad_core.arc import Arc
+from cad_core.lines import Line, Point, trim_segment_by_arc
+
+
+def test_trim_segment_by_arc_basic():
+    # Arc: radius 5 from 0..pi/2 (x>=0,y>=0 quadrant)
+    arc = Arc(center=Point(0, 0), radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    seg = Line(Point(0, 0), Point(10, 0))
+    out = trim_segment_by_arc(seg, arc, end="b")
+    assert out is not None
+    assert abs(out.b.x - 5.0) < 1e-9 and abs(out.b.y - 0.0) < 1e-9
+
+
+def test_trim_segment_by_arc_noop_when_intersection_behind():
+    arc = Arc(center=Point(0, 0), radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    seg = Line(Point(-10, 0), Point(0, 0))
+    out = trim_segment_by_arc(seg, arc, end="a")
+    # Intersection at (5,0) lies beyond 'a'->'b' shortening direction; expect None
+    assert out is None
+
+
+def test_trim_segment_by_arc_tangent_single_point():
+    # Horizontal segment at y=5 ending near x=0 should trim to (0,5)
+    arc = Arc(center=Point(0, 0), radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    seg = Line(Point(-1, 5), Point(1, 5))
+    out = trim_segment_by_arc(seg, arc, end="b")
+    assert out is not None
+    assert abs(out.b.x - 0.0) < 1e-9 and abs(out.b.y - 5.0) < 1e-9


### PR DESCRIPTION
Title: feat(cad_core): add trim_segment_by_arc helper + tests

Summary
- Adds `trim_segment_by_arc` to trim a finite segment to the nearest valid intersection with a finite arc.
- Respects arc sweep and moves the chosen endpoint towards the other endpoint (shortening).
- Includes tests: `tests/cad_core/test_trim_segment_by_arc.py`.

Changes
- Update: `cad_core/arc.py` with `is_point_on_arc` (utility).
- Update: `cad_core/lines.py` with `trim_segment_by_arc` and exports.
- New: `tests/cad_core/test_trim_segment_by_arc.py`.

Test Plan
- `ruff check cad_core tests/cad_core/test_trim_segment_by_arc.py`
- `black --check cad_core tests/cad_core/test_trim_segment_by_arc.py`
- `pytest -q tests/cad_core/test_trim_segment_by_arc.py`

Notes
- Avoids circular imports via local imports and tolerates tiny FP drift.

Refs
- Task: `tasks/feat-cad-core-trim-suite.md`