### PR TITLE
feat(cad_core): extend_segment_to_arc + tests

### DIFF
--- a/tests/cad_core/test_extend_segment_to_arc.py
+++ b/tests/cad_core/test_extend_segment_to_arc.py
@@ -1,0 +1,19 @@
+from cad_core.arc import Arc
+from cad_core.lines import Line, Point, extend_segment_to_arc
+
+
+def test_extend_segment_to_arc_basic():
+    # Arc: radius 5 in quadrant I (0..pi/2)
+    arc = Arc(center=Point(0, 0), radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    seg = Line(Point(0, 0), Point(1, 0))
+    out = extend_segment_to_arc(seg, arc, end="b")
+    assert out is not None
+    assert out.a == seg.a
+    assert abs(out.b.x - 5.0) < 1e-9 and abs(out.b.y - 0.0) < 1e-9
+
+
+def test_extend_segment_to_arc_respects_arc_sweep():
+    # Arc in quadrant I; segment pointing to negative x should not jump across
+    arc = Arc(center=Point(0, 0), radius=5.0, start_angle=0.0, end_angle=1.57079632679, ccw=True)
+    seg = Line(Point(-1, 0), Point(-2, 0))
+    assert extend_segment_to_arc(seg, arc, end="b") is None


### PR DESCRIPTION
Title: feat(cad_core): add extend_segment_to_arc + tests

Summary
- Adds `extend_segment_to_arc` to extend a segment endpoint to the nearest on-arc intersection,
  respecting arc sweep and only moving forward along the segment direction.
- Includes tests: `tests/cad_core/test_extend_segment_to_arc.py`.

Changes
- Update: `cad_core/lines.py` with `extend_segment_to_arc` and export.
- New: `tests/cad_core/test_extend_segment_to_arc.py`.

Test Plan
- `ruff check cad_core tests/cad_core/test_extend_segment_to_arc.py`
- `black --check cad_core tests/cad_core/test_extend_segment_to_arc.py`
- `pytest -q tests/cad_core/test_extend_segment_to_arc.py`

Notes
- Built on top of arc-line trim base (branch `feat/cad-core-trim-extend-arc-line`).
- Avoids circular imports via local imports and string annotations.