### PR TITLE
feat(backend): OpsService.extend_segment_to_circle + test

### DIFF
--- a/backend/ops_service.py
+++ b/backend/ops_service.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from .geom_repo import EntityRef, InMemoryGeomRepo
-from .models import PointDTO, SegmentDTO
+from .models import CircleDTO, PointDTO, SegmentDTO
+
+# Local imports of cad_core inside methods to keep module import light
 
 
 @dataclass
@@ -20,3 +22,48 @@ class OpsService:
         _ = (seg_ref, cut_a, cut_b)
         # TODO: integrate with cad_core.trim operation
         return False
+
+    # DTO/Core adapters
+    @staticmethod
+    def _to_core_point(p: PointDTO):
+        from cad_core.lines import Point as CorePoint
+
+        return CorePoint(float(p.x), float(p.y))
+
+    @classmethod
+    def _to_core_line(cls, s: SegmentDTO):
+        from cad_core.lines import Line as CoreLine
+
+        return CoreLine(cls._to_core_point(s.a), cls._to_core_point(s.b))
+
+    @staticmethod
+    def _to_dto_segment(core_line) -> SegmentDTO:
+        return SegmentDTO(
+            a=PointDTO(x=float(core_line.a.x), y=float(core_line.a.y)),
+            b=PointDTO(x=float(core_line.b.x), y=float(core_line.b.y)),
+        )
+
+    # Integrated CAD operation: extend segment to circle
+    def extend_segment_to_circle(
+        self, seg_ref: EntityRef, circle: CircleDTO, end: str = "b"
+    ) -> bool:
+        """Extend a segment stored in the repo to the nearest circle intersection.
+
+        Updates the segment in-place in the repo on success.
+        """
+        if seg_ref.kind != "segment":
+            return False
+        seg = self.repo.get_segment(seg_ref.id)
+        if seg is None:
+            return False
+
+        from cad_core.circle import Circle as CoreCircle
+        from cad_core.lines import extend_segment_to_circle
+
+        core_seg = self._to_core_line(seg)
+        core_circ = CoreCircle(self._to_core_point(circle.center), float(circle.r))
+        out = extend_segment_to_circle(core_seg, core_circ, end=end)
+        if out is None:
+            return False
+        new_seg = self._to_dto_segment(out)
+        return self.repo.update_segment(seg_ref.id, new_seg)

--- a/tests/backend/test_ops_integration_extend_circle.py
+++ b/tests/backend/test_ops_integration_extend_circle.py
@@ -1,0 +1,19 @@
+from backend.geom_repo import InMemoryGeomRepo
+from backend.models import CircleDTO, PointDTO, SegmentDTO
+from backend.ops_service import OpsService
+
+
+def test_ops_extend_segment_to_circle_updates_repo():
+    repo = InMemoryGeomRepo()
+    svc = OpsService(repo=repo)
+
+    # Seed a segment along +X from origin
+    seg_ref = repo.add_segment(SegmentDTO(PointDTO(0, 0), PointDTO(1, 0)))
+    # Define a circle of radius 5 centered at origin
+    circle = CircleDTO(center=PointDTO(0, 0), r=5.0)
+
+    ok = svc.extend_segment_to_circle(seg_ref, circle, end="b")
+    assert ok is True
+    updated = repo.get_segment(seg_ref.id)
+    assert updated is not None
+    assert abs(updated.b.x - 5.0) < 1e-9 and abs(updated.b.y - 0.0) < 1e-9


### PR DESCRIPTION
Title: feat(backend): integrate CAD core extend_segment_to_circle in OpsService

Summary
- Adds `OpsService.extend_segment_to_circle(seg_ref, circle, end)` that updates a stored segment to
  the nearest circle intersection using `cad_core.lines.extend_segment_to_circle`.
- Includes a focused integration test with `InMemoryGeomRepo`.

Changes
- Update: `backend/ops_service.py` (DTO<->core adapters + integration method).
- New: `tests/backend/test_ops_integration_extend_circle.py`.

Test Plan
- `ruff check backend/ops_service.py tests/backend/test_ops_integration_extend_circle.py`
- `black --check backend/ops_service.py tests/backend/test_ops_integration_extend_circle.py`
- `pytest -q tests/backend/test_ops_integration_extend_circle.py`

Notes
- Local imports and string annotations avoid import cycles.
- Returns `False` if the segment ref is invalid or no intersection exists.