### PR TITLE
feat(frontend): passive OpsAdapter + tool registration

### DIFF
--- a/frontend/integration.py
+++ b/frontend/integration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+# Frontend-side adapter for backend OpsService.
+# Passive wiring: provides an adapter class and optional tool registration
+# without touching the active UI. Import in UI code when ready to expose.
+from dataclasses import dataclass
+
+from backend.geom_repo import EntityRef, InMemoryGeomRepo
+from backend.models import CircleDTO, PointDTO
+from backend.ops_service import OpsService
+
+from .tool_registry import ToolSpec, register
+
+
+@dataclass
+class OpsAdapter:
+    repo: InMemoryGeomRepo
+    svc: OpsService
+
+    def extend_segment_to_circle(
+        self, seg_id: str, center_x: float, center_y: float, r: float, end: str = "b"
+    ) -> bool:
+        ref = EntityRef("segment", seg_id)
+        circle = CircleDTO(center=PointDTO(center_x, center_y), r=float(r))
+        return self.svc.extend_segment_to_circle(ref, circle, end=end)
+
+
+def build_adapter(repo: InMemoryGeomRepo | None = None) -> OpsAdapter:
+    repo = repo or InMemoryGeomRepo()
+    svc = OpsService(repo=repo)
+    return OpsAdapter(repo=repo, svc=svc)
+
+
+def register_ops_tools(prefix: str = "ops") -> None:
+    """Register passive tools for ops; safe to call multiple times."""
+
+    def factory():
+        # Factory returns a new adapter instance; UI can bind actions to its methods.
+        return build_adapter()
+
+    register(
+        ToolSpec(
+            name="Extend Segment to Circle",
+            command=f"{prefix}.extend_to_circle",
+            shortcut=None,
+            icon=None,
+            factory=factory,
+        )
+    )
+
+
+__all__ = ["OpsAdapter", "build_adapter", "register_ops_tools"]

--- a/tests/frontend/test_ops_adapter.py
+++ b/tests/frontend/test_ops_adapter.py
@@ -1,0 +1,25 @@
+import pytest
+
+from frontend.integration import build_adapter, register_ops_tools
+
+
+def test_build_adapter_and_extend_segment():
+    from backend.models import PointDTO, SegmentDTO
+
+    adapter = build_adapter()
+    if not hasattr(adapter.svc, "extend_segment_to_circle"):
+        pytest.skip("backend OpsService does not expose extend_segment_to_circle on this branch")
+    seg_ref = adapter.repo.add_segment(SegmentDTO(PointDTO(0, 0), PointDTO(1, 0)))
+    ok = adapter.extend_segment_to_circle(seg_ref.id, 0.0, 0.0, 5.0, end="b")
+    assert ok is True
+    seg = adapter.repo.get_segment(seg_ref.id)
+    assert seg is not None
+    assert abs(seg.b.x - 5.0) < 1e-9 and abs(seg.b.y - 0.0) < 1e-9
+
+
+def test_register_ops_tools_registers_factory():
+    register_ops_tools()
+    from frontend.tool_registry import get
+
+    spec = get("ops.extend_to_circle")
+    assert spec is not None and callable(spec.factory)


### PR DESCRIPTION
Title: feat(frontend): passive OpsAdapter + tool registration

Summary
- Adds `frontend.integration.OpsAdapter` to call backend OpsService methods from UI without changing existing UI.
- Registers a passive tool (`ops.extend_to_circle`) that returns an adapter via factory for future binding.
- Includes an integration test that seeds a segment and attempts an extend-to-circle call; test is skipped if backend op missing.

Changes
- New: `frontend/integration.py`
- New: `tests/frontend/test_ops_adapter.py`

Test Plan
- `ruff check frontend/integration.py tests/frontend/test_ops_adapter.py`
- `black --check frontend/integration.py tests/frontend/test_ops_adapter.py`
- `pytest -q tests/frontend/test_ops_adapter.py` (1 passed, 1 skipped if backend op absent)

Notes
- No UI entry points are modified; this is passive wiring ready for later UI exposure.