### PR TITLE
chore(ci): enable manual CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Add workflow_dispatch to CI so we can run tests on demand via GitHub runner. No behavior change for push/PR events.